### PR TITLE
fix(app.module): remove duplicate service providers in AppModule

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -476,7 +476,6 @@ import { FeedbackModule } from './platform-feedback/feedback.module';
     CoCategoryService, FeedbackTypes, LocationService, UserBeneficiaryData, CoFeedbackService,
     CzentrixServices, PrescriptionService, CaseSheetService, OtherHelplineService,
     SioService, EpidemicServices, CDSSService, OrganDonationServices, BloodOnCallServices, CallerService, FoodSafetyServices, ConfigService,sessionStorageService,
-    SioService, EpidemicServices, CDSSService, OrganDonationServices, BloodOnCallServices, CallerService, FoodSafetyServices, ConfigService,
     DiseaseScreeningService, OutboundSearchRecordService, OutboundCallAllocationService, OutboundReAllocationService,
     OutboundWorklistService, AvailableServices, SupervisorCallTypeReportService, FeedbackService,
     UploadServiceService, AuthGuard, AuthGuard2, SaveFormsGuard, CallTypeReportService,


### PR DESCRIPTION
## 📋 Description

JIRA ID: N/A

The `providers` array in `AppModule` registered 8 services twice on consecutive lines:
SioService, EpidemicServices, CDSSService, OrganDonationServices, BloodOnCallServices, CallerService, FoodSafetyServices, ConfigService

Angular silently resolves duplicate root providers by using the last registration, which can cause components to receive different instances of stateful services depending on injection order. Services like `CallerService` and `CDSSService` hold active call session state, making this a silent runtime risk in a live helpline environment.

The duplicate line has been removed. The surviving line correctly retains all 9 intended providers including `sessionStorageService`.

---

## ✅ Type of Change

- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)

---

## ℹ️ Additional Information

**How tested:** Manually verified the `providers` array before and after the change. All 9 services (`SioService`, `EpidemicServices`, `CDSSService`, `OrganDonationServices`, `BloodOnCallServices`, `CallerService`, `FoodSafetyServices`, `ConfigService`, `sessionStorageService`) remain registered exactly once in the root injector.

No behaviour change is expected at runtime for a correctly functioning session this fix eliminates the risk of duplicate instantiation that would otherwise surface as subtle state inconsistencies during active calls.

**Migration note:** This is also a prerequisite cleanup for the Angular 19 migration. Moving to standalone components and `provideX()` functions will make duplicate provider registrations a hard error rather than a silent one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed duplicate service provider registrations to improve code quality and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->