### PR TITLE
docs: improve local setup instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,15 @@ To install the Helpline104 module, please follow these steps:
    npm install --force
    ```
 4. Configure your local environment by editing `src/environments/environment.local.ts` with your local API URLs.
-5. Start the development server:
+5. Copy the local environment file:
    ```bash
-   npm run dev
+   cp src/environments/environment.local.ts src/environments/environment.ts
    ```
-6. Open your browser and access `http://localhost:4200/#/login` to view the login page of module.
+6. Start the development server:
+   ```bash
+   npm start
+   ```
+7. Open your browser and access `http://localhost:4200/#/login` to view the login page of module.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -30,25 +30,37 @@ To build the Helpline104 microservice from source, follow these steps:
 
 ### Prerequisites
 
-Ensure that the following prerequisites are met before building the MMU service:
+Ensure that the following prerequisites are met before building the Helpline104 service:
 
 * JDK 1.8
 * Maven
+* Node.js v16
 * NPM/YARN
 * Spring Boot v2
 * MySQL
 
 ### Installation
 
-To install the MMU module, please follow these steps:
+To install the Helpline104 module, please follow these steps:
 
 1. Clone the repository to your local machine.
-2. Install the dependencies and build the module:
-   - Run the command `npm install`.
-   - Run the command `npm run build`.
-   - Run the command `mvn clean install`.
-   - Run the command `npm start`.
-3. Open your browser and access `http://localhost:4200/#/login` to view the login page of module.
+2. Install Node.js v16 (recommended via [nvm](https://github.com/nvm-sh/nvm)):
+   ```bash
+   nvm install 16
+   nvm use 16
+   ```
+3. Install the dependencies:
+   ```bash
+   npm config set legacy-peer-deps true
+   npm install node-sass --force
+   npm install --force
+   ```
+4. Configure your local environment by editing `src/environments/environment.local.ts` with your local API URLs.
+5. Start the development server:
+   ```bash
+   npm run dev
+   ```
+6. Open your browser and access `http://localhost:4200/#/login` to view the login page of module.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "ng": "ng",
     "postinstall": "node version.js",
     "start": "node version.js && ng serve -o",
+    "dev": "node version.js && ng serve -o --env=local",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "ng": "ng",
     "postinstall": "node version.js",
     "start": "node version.js && ng serve -o",
-    "dev": "node version.js && ng serve -o --env=local",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",


### PR DESCRIPTION
## Summary

- Updated README prerequisites to specify Node.js v16
- Improved installation steps with correct `npm install` sequence (matching CI workflow)
- Added step to copy local environment file to `environment.ts`
- Updated local start command to `npm start`

Issue: PSMRI/AMRIT#111

## Test plan

- [ ] Follow README steps end-to-end and verify the app starts at `http://localhost:4200/#/login`
- [ ] Verify `cp src/environments/environment.local.ts src/environments/environment.ts` works before `npm start`