### PR TITLE
fix: replace fdescribe with describe in test files to enable full test suite

### DIFF
--- a/src/app/104-co/104-co.component.spec.ts
+++ b/src/app/104-co/104-co.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -90,7 +90,7 @@ function Initialize104coTestBed() {
 
 describe('Co_104_Component', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104coTestBed();
 

--- a/src/app/104-hao/104-hao.component.spec.ts
+++ b/src/app/104-hao/104-hao.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -46,7 +46,7 @@ const providerForFakeDataService = {
 };
 
 const fakeRouter = {
-  
+
 };
 
 const providerForFakeRouter = {
@@ -95,7 +95,7 @@ function Initialize104haoTestBed(){
 
 describe('Hao_104_Component', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104haoTestBed();
 

--- a/src/app/104-mo/104-mo.component.spec.ts
+++ b/src/app/104-mo/104-mo.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -105,7 +105,7 @@ function Initialize104moTestBed() {
 
 describe('Mo_104_Component', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104moTestBed();
 

--- a/src/app/104-pd/104-pd.component.spec.ts
+++ b/src/app/104-pd/104-pd.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -92,7 +92,7 @@ function Initialize104pdTestBed() {
 describe('Pd_104_Component', () => {
 
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104pdTestBed();
 

--- a/src/app/104-ro/104-ro.component.spec.ts
+++ b/src/app/104-ro/104-ro.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -99,7 +99,7 @@ function Initialize104roTestBed() {
 
 describe('Ro_104_Component', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104roTestBed();
 

--- a/src/app/104-sio/104-sio.component.spec.ts
+++ b/src/app/104-sio/104-sio.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -94,7 +94,7 @@ function Initialize104roTestBed() {
 
 describe('Sio_104_Component', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104roTestBed();
 

--- a/src/app/104-supervisor/104-supervisor.component.spec.ts
+++ b/src/app/104-supervisor/104-supervisor.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -57,8 +57,8 @@ function Initialize104supervisorTestBed() {
 }
 
 describe('Supervisor_104_Component', () => {
-  
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104supervisorTestBed();
 

--- a/src/app/104-surveyor/104-surveyor.component.spec.ts
+++ b/src/app/104-surveyor/104-surveyor.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -48,7 +48,7 @@ function Initialize104surveyorTestBed(){
 
 describe('surveyor_104_Component', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104surveyorTestBed();
 

--- a/src/app/104/104.component.spec.ts
+++ b/src/app/104/104.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -97,7 +97,7 @@ function Initialize104TestBed() {
 
 describe('Helpline_104_Component', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104TestBed();
 

--- a/src/app/104Services/104-services.component.spec.ts
+++ b/src/app/104Services/104-services.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -150,7 +150,7 @@ function Initialize104servicesTestBed(){
 
 describe('ServicesComponent', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104servicesTestBed();
 

--- a/src/app/activity-this-week/activity-this-week.component.spec.ts
+++ b/src/app/activity-this-week/activity-this-week.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -32,7 +32,7 @@ let fixture: ComponentFixture<ActivityThisWeekComponent>;
 
 const FakeDataService = {
    current_role: '',
-   current_campaign: '' 
+   current_campaign: ''
 }
 
 const providerForFakeDataService = {
@@ -67,7 +67,7 @@ function InitializeActivityThisWeekTestBed() {
 
 describe('ActivityThisWeekComponent', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     InitializeActivityThisWeekTestBed();
 

--- a/src/app/agent-outbondcall/agent-outbondcall.component.spec.ts
+++ b/src/app/agent-outbondcall/agent-outbondcall.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -66,7 +66,7 @@ function InitializeAgentOutboundCallTestBed() {
 
 describe('AgentOutbondcallComponent', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     InitializeAgentOutboundCallTestBed();
 

--- a/src/app/agent-status/agent-status.component.spec.ts
+++ b/src/app/agent-status/agent-status.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -84,7 +84,7 @@ function InitializeAgentStatusTestBed() {
 
 describe('AgentStatusComponent', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     InitializeAgentStatusTestBed();
 

--- a/src/app/alernate-email-model/alernate-email-model.component.spec.ts
+++ b/src/app/alernate-email-model/alernate-email-model.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -71,7 +71,7 @@ function InitializeAlternateEmailModelTestBed() {
 }
 
 describe('AlernateEmailModelComponent', () => {
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     InitializeAlternateEmailModelTestBed();
 

--- a/src/app/case-sheet/case-sheet.component.spec.ts
+++ b/src/app/case-sheet/case-sheet.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -178,7 +178,7 @@ describe('CaseSheetComponent', () => {
     dataServiceInstance = TestBed.get(dataService);
   });
 
-  fdescribe('case sheet on init ()', () => {
+  describe('case sheet on init ()', () => {
     it('should be created', () => {
       expect(component).toBeTruthy();
     });

--- a/src/app/sio-scheme-service/sio-scheme-service.component.spec.ts
+++ b/src/app/sio-scheme-service/sio-scheme-service.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -82,7 +82,7 @@ function Initialize104TestBed() {
 }
 describe('Sio-scheme-service', () => {
 
-    fdescribe('When the component is getting loaded, then ngOninit', () => {
+    describe('When the component is getting loaded, then ngOninit', () => {
 
         Initialize104TestBed();
 

--- a/src/app/supervisor-alerts-notifications/supervisor-alerts-notifications.component.spec.ts
+++ b/src/app/supervisor-alerts-notifications/supervisor-alerts-notifications.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -108,7 +108,7 @@ function Initialize104TestBed() {
 }
 describe('Supervisor-alerts-notifications', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104TestBed();
 

--- a/src/app/supervisor-blood-url/supervisor-blood-url.component.spec.ts
+++ b/src/app/supervisor-blood-url/supervisor-blood-url.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -84,7 +84,7 @@ function Initialize104TestBed() {
 }
 describe('Supervisor-blood-url', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104TestBed();
 

--- a/src/app/supervisor-configurations/supervisor-configurations.component.spec.ts
+++ b/src/app/supervisor-configurations/supervisor-configurations.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -54,7 +54,7 @@ function Initialize104TestBed() {
 }
 describe('Supervisor-configurations-component', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104TestBed();
 

--- a/src/app/supervisor-emergency-contacts/supervisor-emergency-contacts.component.spec.ts
+++ b/src/app/supervisor-emergency-contacts/supervisor-emergency-contacts.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -104,7 +104,7 @@ function Initialize104TestBed() {
 }
 describe('Supervisor-emergency-contacts', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104TestBed();
 

--- a/src/app/supervisor-location-communication/supervisor-location-communication.component.spec.ts
+++ b/src/app/supervisor-location-communication/supervisor-location-communication.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -101,7 +101,7 @@ function Initialize104TestBed() {
 }
 describe('Supervisor-location-communication', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104TestBed();
 

--- a/src/app/supervisor-notifications/supervisor-notifications.component.spec.ts
+++ b/src/app/supervisor-notifications/supervisor-notifications.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -132,7 +132,7 @@ function Initialize104coTestBed() {
     });
 }
 describe('SupervisorNotificationsComponent Testbed creation', () => {
-    fdescribe('When the component is getting loaded, then ngOninit', () => {
+    describe('When the component is getting loaded, then ngOninit', () => {
         Initialize104coTestBed()
 
         it('should be created', () => {

--- a/src/app/supervisor-reports/supervisor-reports.component.spec.ts
+++ b/src/app/supervisor-reports/supervisor-reports.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -80,7 +80,7 @@ function Initialize104coTestBed() {
 
 describe('Supervisor-reports', () => {
 
-    fdescribe('When the component is getting loaded, then ngOninit', () => {
+    describe('When the component is getting loaded, then ngOninit', () => {
 
         Initialize104coTestBed();
 

--- a/src/app/supervisor-training-resources/supervisor-training-resources.component.spec.ts
+++ b/src/app/supervisor-training-resources/supervisor-training-resources.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -107,7 +107,7 @@ function Initialize104coTestBed() {
 
 describe('Supervisor-Training-resources', () => {
 
-    fdescribe('When the component is getting loaded, then ngOninit', () => {
+    describe('When the component is getting loaded, then ngOninit', () => {
 
         Initialize104coTestBed();
 

--- a/src/app/supervisor-upload-schemes/supervisor-upload-schemes.spec.ts
+++ b/src/app/supervisor-upload-schemes/supervisor-upload-schemes.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -108,7 +108,7 @@ function Initialize104TestBed() {
 }
 describe('Supervisor-upload-schemes', () => {
 
-    fdescribe('When the component is getting loaded, then ngOninit', () => {
+    describe('When the component is getting loaded, then ngOninit', () => {
 
         Initialize104TestBed();
 

--- a/src/app/training-resources/training-resources.component.spec.ts
+++ b/src/app/training-resources/training-resources.component.spec.ts
@@ -1,8 +1,8 @@
-/* 
-* AMRIT – Accessible Medical Records via Integrated Technology 
-* Integrated EHR (Electronic Health Records) Solution 
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
 *
-* Copyright (C) "Piramal Swasthya Management and Research Institute" 
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
 *
 * This file is part of AMRIT.
 *
@@ -109,7 +109,7 @@ function Initialize104coTestBed() {
 
 describe('Training-resources', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104coTestBed();
 


### PR DESCRIPTION
## 📋 Description
Fixes a critical testing issue where fdescribe() was used across 25 spec files, preventing the full test suite from running. 
Only the focused tests were executing during CI.

Related to PSMRI/AMRIT#129 (C4GT DMP 2026)

## ✅ Type of Change
- [x] 🐞 Bug fix
- [x] 🧪 Tests

## ℹ️ Additional Information
- 25 spec files fixed
- fdescribe() is explicitly forbidden in tslint.json but was widespread
- Commented-out fdescribe() lines left untouched intentionally
- No logic changes, pure test configuration fix