### PR TITLE
feat(ui): optional remember User ID on login screen

### DIFF
--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -58,6 +58,9 @@ export class loginContentClass implements OnInit {
   encryptpassword: any;
   captchaToken: string;
   enableCaptcha = environment.enableCaptcha;
+  rememberUserId = false;
+  private readonly rememberUserStorageKey = "104_login_remember_user";
+  private readonly savedUsernameStorageKey = "104_login_saved_username";
 
   constructor(
     public loginservice: loginService,
@@ -88,6 +91,7 @@ export class loginContentClass implements OnInit {
   }
 
   ngOnInit() {
+    this.restoreRememberedUserId();
     /*
       JA354063 - Added on 21/4/2022
       Purpose - If user already logged in , kick the prev session and create a new session
@@ -287,6 +291,7 @@ export class loginContentClass implements OnInit {
         return userPrivelige.serviceName == "104";
     });
     if (this.privleges.length > 0) {
+      this.persistRememberUserPreference();
       this.dataSettingService.Userdata = response;
 
       let previlageObj: any = [];
@@ -398,6 +403,30 @@ export class loginContentClass implements OnInit {
       this.captchaCmp.reset();
       this.captchaToken = '';
     }
+  }
+
+  private restoreRememberedUserId() {
+    try {
+      if (sessionStorage.getItem(this.rememberUserStorageKey) === "true") {
+        this.rememberUserId = true;
+        const saved = sessionStorage.getItem(this.savedUsernameStorageKey);
+        if (saved) {
+          this.userID = saved;
+        }
+      }
+    } catch (_) { /* sessionStorage unavailable */ }
+  }
+
+  private persistRememberUserPreference() {
+    try {
+      if (this.rememberUserId && this.userID) {
+        sessionStorage.setItem(this.rememberUserStorageKey, "true");
+        sessionStorage.setItem(this.savedUsernameStorageKey, String(this.userID).trim());
+      } else {
+        sessionStorage.removeItem(this.rememberUserStorageKey);
+        sessionStorage.removeItem(this.savedUsernameStorageKey);
+      }
+    } catch (_) { /* sessionStorage unavailable */ }
   }
 
   // getServiceProviderMapIDSuccessHandeler(response)

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -407,26 +407,38 @@ export class loginContentClass implements OnInit {
 
   private restoreRememberedUserId() {
     try {
-      if (sessionStorage.getItem(this.rememberUserStorageKey) === "true") {
+      if (
+        localStorage.getItem(this.rememberUserStorageKey) !== "true" &&
+        sessionStorage.getItem(this.rememberUserStorageKey) === "true"
+      ) {
+        const legacyUser = sessionStorage.getItem(this.savedUsernameStorageKey);
+        if (legacyUser) {
+          localStorage.setItem(this.rememberUserStorageKey, "true");
+          localStorage.setItem(this.savedUsernameStorageKey, legacyUser);
+        }
+        sessionStorage.removeItem(this.rememberUserStorageKey);
+        sessionStorage.removeItem(this.savedUsernameStorageKey);
+      }
+      if (localStorage.getItem(this.rememberUserStorageKey) === "true") {
         this.rememberUserId = true;
-        const saved = sessionStorage.getItem(this.savedUsernameStorageKey);
+        const saved = localStorage.getItem(this.savedUsernameStorageKey);
         if (saved) {
           this.userID = saved;
         }
       }
-    } catch (_) { /* sessionStorage unavailable */ }
+    } catch (_) { /* localStorage unavailable */ }
   }
 
   private persistRememberUserPreference() {
     try {
       if (this.rememberUserId && this.userID) {
-        sessionStorage.setItem(this.rememberUserStorageKey, "true");
-        sessionStorage.setItem(this.savedUsernameStorageKey, String(this.userID).trim());
+        localStorage.setItem(this.rememberUserStorageKey, "true");
+        localStorage.setItem(this.savedUsernameStorageKey, String(this.userID).trim());
       } else {
-        sessionStorage.removeItem(this.rememberUserStorageKey);
-        sessionStorage.removeItem(this.savedUsernameStorageKey);
+        localStorage.removeItem(this.rememberUserStorageKey);
+        localStorage.removeItem(this.savedUsernameStorageKey);
       }
-    } catch (_) { /* sessionStorage unavailable */ }
+    } catch (_) { /* localStorage unavailable */ }
   }
 
   // getServiceProviderMapIDSuccessHandeler(response)

--- a/src/app/login/login.html
+++ b/src/app/login/login.html
@@ -28,6 +28,11 @@
                 </md-input-container>
               </div>
             </div>
+            <div class="row">
+              <div class="col-xs-12 col-md-12 col-sm-12">
+                <md-checkbox name="rememberUserId" [(ngModel)]="rememberUserId" color="primary">Remember User ID on this device</md-checkbox>
+              </div>
+            </div>
             <div *ngIf="enableCaptcha" class="row" role="group" aria-labelledby="captcha-label">
               <label id="captcha-label" class="sr-only">Security check</label>
               <app-captcha #captchaCmp style="display: flex;justify-content: center;" (tokenResolved)="onCaptchaResolved($event)"></app-captcha>


### PR DESCRIPTION
## 📋 Description
Adds an optional “Remember User ID on this device” checkbox on the login screen. When checked and login succeeds, the user ID is stored in sessionStorage; on the next visit the field is pre-filled. Unchecking clears stored preference on successful login.
JIRA ID: 

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [x] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [x] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Remember User ID on this device" option on the login page. When enabled, your previously entered user ID will be automatically restored when you return to the login page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PSMRI/Helpline104-UI/pull/69)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->