### PR TITLE
feat(ui): show beneficiary phone with one-click copy on innerpage strip

### DIFF
--- a/src/app/innerpage/innerpage.component.html
+++ b/src/app/innerpage/innerpage.component.html
@@ -62,6 +62,12 @@
           <ul class="list-inline list-unstyled pull-left">
           </ul>
           <ul class="list-unstyled list-inline pull-left p-a-0 m-b-0">
+            <li class="f-s-16 f-c-0 p-l-20" *ngIf="selectedBenData.mob">
+              <strong>{{currentLanguageSet?.phone || 'Phone'}}:</strong> {{selectedBenData.mob}}
+              <md-icon class="cursorPointer mat-icon material-icons m-l-5" role="button" tabindex="0"
+                [mdTooltip]="currentLanguageSet?.copyPhone || 'Copy phone'"
+                (click)="copyBeneficiaryPhone()" (keydown.enter)="copyBeneficiaryPhone()">content_copy</md-icon>
+            </li>
             <li class="f-s-16 f-c-0 p-l-20" *ngIf="selectedBenData.fullname"><strong>{{selectedBenData.fullname ? selectedBenData.fullname+', ' : ''}}</strong></li>
             <li *ngIf="selectedBenData.id">{{selectedBenData.id ? selectedBenData.id+', ' : ''}}</li>
             <!-- SH20094090,23-092021,HealthID Integration changes on Innerpage -->

--- a/src/app/innerpage/innerpage.component.ts
+++ b/src/app/innerpage/innerpage.component.ts
@@ -910,5 +910,48 @@ export class InnerpageComponent implements OnInit, OnDestroy {
     );
     languageSubscription.unsubscribe();
   }
+
+  copyBeneficiaryPhone() {
+    const raw = this.selectedBenData && this.selectedBenData.mob;
+    const text = raw != null ? String(raw).trim() : "";
+    if (!text) {
+      return;
+    }
+    const done = () =>
+      this.message.alert(
+        (this.currentLanguageSet && this.currentLanguageSet.phoneCopied) ||
+          "Phone number copied",
+        "success"
+      );
+    try {
+      const nav: any = navigator;
+      if (nav.clipboard && typeof nav.clipboard.writeText === "function") {
+        nav.clipboard.writeText(text).then(done).catch(() => this.fallbackCopyText(text, done));
+        return;
+      }
+    } catch (_) { /* continue fallback */ }
+    this.fallbackCopyText(text, done);
+  }
+
+  private fallbackCopyText(text: string, onOk: () => void) {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    ta.style.position = "fixed";
+    ta.style.left = "-9999px";
+    document.body.appendChild(ta);
+    ta.select();
+    try {
+      document.execCommand("copy");
+      onOk();
+    } catch (_) {
+      this.message.alert(
+        (this.currentLanguageSet && this.currentLanguageSet.copyFailed) ||
+          "Could not copy phone number",
+        "error"
+      );
+    }
+    document.body.removeChild(ta);
+  }
+
   /*END - Methods for multilingual implementation*/
 }


### PR DESCRIPTION
## 📋 Description
Shows the beneficiary phone on the innerpage header strip when selectedBenData.mob is present, with a copy control. Uses navigator.clipboard.writeText when available, with document.execCommand('copy') fallback; success/error surfaced via existing ConfirmationDialogsService.

JIRA ID: 

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [x] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [x] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
