### PR TITLE
feat(ui): add dashboard refresh control for alerts and widgets

### DIFF
--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -207,6 +207,10 @@ export class dashboardContentClass implements OnInit {
     // this.testEvent();
   }
 
+  refreshDashboardWidgets() {
+    this.alertRefresh++;
+  }
+
   // testing event
   testEvent() {
     // var event = new Event('message');

--- a/src/app/dashboard/dashboard.html
+++ b/src/app/dashboard/dashboard.html
@@ -24,6 +24,11 @@
               <div class="pull-left ">
                 <dashboard-user-id (click)="testEvent()" *ngIf="current_role!='Supervisor'"></dashboard-user-id>
               </div>
+              <div class="pull-right p-t-5">
+                <button md-icon-button type="button" (click)="refreshDashboardWidgets()" mdTooltip="Refresh dashboard">
+                  <md-icon>refresh</md-icon>
+                </button>
+              </div>
               <div class="pull-right p-t-10 p-b-10" *ngIf="current_role=='MO' || current_role=='CO' || current_role=='SIO' || current_role=='HAO' || hasHAOPrivilege || current_role == 'PD'">
                 <md-radio-group name=" inOutBound" (change)="campaign(inOutBound)" [(ngModel)]="inOutBound">
                   <md-radio-button color="primary" value='1'>{{assignSelectedLanguageValue?.inbound}}</md-radio-button>


### PR DESCRIPTION
## 📋 Description
Adds a Refresh icon button on the dashboard toolbar. Clicking increments alertRefresh, which existing child components (e.g. alerts/notifications) already use to reload data.

JIRA ID: 

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [x] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [x] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
