### PR TITLE
feat(ui): show current calendar year in multi-role screen footer

### DIFF
--- a/src/app/multi-role-screen/multi-role-screen.component.html
+++ b/src/app/multi-role-screen/multi-role-screen.component.html
@@ -70,7 +70,7 @@
         <span class="footer-text">{{currentLanguageSet?.poweredByWipro}}</span>
       </div>
       <div class="col-lg-5 col-md-5 col-sm-5 col-xs-5">
-        <p class="footer-text t-a-c">2018
+        <p class="footer-text t-a-c">{{copyrightYear}}
           <md-icon color="" class="copyright_icon">copyright</md-icon>{{currentLanguageSet?.psmri}} </p>
       </div>
       <div class="col-sm-3 col-xs-3" style="cursor: pointer"

--- a/src/app/multi-role-screen/multi-role-screen.component.ts
+++ b/src/app/multi-role-screen/multi-role-screen.component.ts
@@ -70,6 +70,7 @@ export class MultiRoleScreenComponent implements OnInit {
   language_file_path: any = "./assets/";
   currentLanguageSet: any;
   app_language: any;
+  copyrightYear = new Date().getFullYear();
 
   constructor(
     private sessionstorage:sessionStorageService,


### PR DESCRIPTION
## 📋 Description
Replaces the hardcoded 2018 copyright year in the multi-role screen footer with new Date().getFullYear() via a copyrightYear field on the component.

JIRA ID: 

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [x] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
