### PR TITLE
Refactor: Replace fdescribe with describe in test specs

### DIFF
--- a/src/app/104-co/104-co.component.spec.ts
+++ b/src/app/104-co/104-co.component.spec.ts
@@ -90,7 +90,7 @@ function Initialize104coTestBed() {
 
 describe('Co_104_Component', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104coTestBed();
 

--- a/src/app/104-hao/104-hao.component.spec.ts
+++ b/src/app/104-hao/104-hao.component.spec.ts
@@ -95,7 +95,7 @@ function Initialize104haoTestBed(){
 
 describe('Hao_104_Component', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104haoTestBed();
 

--- a/src/app/104-mo/104-mo.component.spec.ts
+++ b/src/app/104-mo/104-mo.component.spec.ts
@@ -105,7 +105,7 @@ function Initialize104moTestBed() {
 
 describe('Mo_104_Component', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104moTestBed();
 

--- a/src/app/104-pd/104-pd.component.spec.ts
+++ b/src/app/104-pd/104-pd.component.spec.ts
@@ -92,7 +92,7 @@ function Initialize104pdTestBed() {
 describe('Pd_104_Component', () => {
 
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104pdTestBed();
 

--- a/src/app/104-ro/104-ro.component.spec.ts
+++ b/src/app/104-ro/104-ro.component.spec.ts
@@ -99,7 +99,7 @@ function Initialize104roTestBed() {
 
 describe('Ro_104_Component', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104roTestBed();
 

--- a/src/app/104-sio/104-sio.component.spec.ts
+++ b/src/app/104-sio/104-sio.component.spec.ts
@@ -94,7 +94,7 @@ function Initialize104roTestBed() {
 
 describe('Sio_104_Component', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104roTestBed();
 

--- a/src/app/104-supervisor/104-supervisor.component.spec.ts
+++ b/src/app/104-supervisor/104-supervisor.component.spec.ts
@@ -58,7 +58,7 @@ function Initialize104supervisorTestBed() {
 
 describe('Supervisor_104_Component', () => {
   
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104supervisorTestBed();
 

--- a/src/app/104-surveyor/104-surveyor.component.spec.ts
+++ b/src/app/104-surveyor/104-surveyor.component.spec.ts
@@ -48,7 +48,7 @@ function Initialize104surveyorTestBed(){
 
 describe('surveyor_104_Component', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104surveyorTestBed();
 

--- a/src/app/104/104.component.spec.ts
+++ b/src/app/104/104.component.spec.ts
@@ -97,7 +97,7 @@ function Initialize104TestBed() {
 
 describe('Helpline_104_Component', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104TestBed();
 

--- a/src/app/104Services/104-services.component.spec.ts
+++ b/src/app/104Services/104-services.component.spec.ts
@@ -150,7 +150,7 @@ function Initialize104servicesTestBed(){
 
 describe('ServicesComponent', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104servicesTestBed();
 

--- a/src/app/activity-this-week/activity-this-week.component.spec.ts
+++ b/src/app/activity-this-week/activity-this-week.component.spec.ts
@@ -67,7 +67,7 @@ function InitializeActivityThisWeekTestBed() {
 
 describe('ActivityThisWeekComponent', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     InitializeActivityThisWeekTestBed();
 

--- a/src/app/agent-outbondcall/agent-outbondcall.component.spec.ts
+++ b/src/app/agent-outbondcall/agent-outbondcall.component.spec.ts
@@ -66,7 +66,7 @@ function InitializeAgentOutboundCallTestBed() {
 
 describe('AgentOutbondcallComponent', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     InitializeAgentOutboundCallTestBed();
 

--- a/src/app/agent-status/agent-status.component.spec.ts
+++ b/src/app/agent-status/agent-status.component.spec.ts
@@ -84,7 +84,7 @@ function InitializeAgentStatusTestBed() {
 
 describe('AgentStatusComponent', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     InitializeAgentStatusTestBed();
 

--- a/src/app/alernate-email-model/alernate-email-model.component.spec.ts
+++ b/src/app/alernate-email-model/alernate-email-model.component.spec.ts
@@ -71,7 +71,7 @@ function InitializeAlternateEmailModelTestBed() {
 }
 
 describe('AlernateEmailModelComponent', () => {
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     InitializeAlternateEmailModelTestBed();
 

--- a/src/app/case-sheet/case-sheet.component.spec.ts
+++ b/src/app/case-sheet/case-sheet.component.spec.ts
@@ -178,7 +178,7 @@ describe('CaseSheetComponent', () => {
     dataServiceInstance = TestBed.get(dataService);
   });
 
-  fdescribe('case sheet on init ()', () => {
+  describe('case sheet on init ()', () => {
     it('should be created', () => {
       expect(component).toBeTruthy();
     });

--- a/src/app/sio-scheme-service/sio-scheme-service.component.spec.ts
+++ b/src/app/sio-scheme-service/sio-scheme-service.component.spec.ts
@@ -82,7 +82,7 @@ function Initialize104TestBed() {
 }
 describe('Sio-scheme-service', () => {
 
-    fdescribe('When the component is getting loaded, then ngOninit', () => {
+    describe('When the component is getting loaded, then ngOninit', () => {
 
         Initialize104TestBed();
 

--- a/src/app/sio-services-history/sio-services-history.component.spec.ts
+++ b/src/app/sio-services-history/sio-services-history.component.spec.ts
@@ -80,7 +80,7 @@
 // }
 // describe('Sio-history-components', () => {
 
-//     fdescribe('When the component is getting loaded, then ngOninit', () => {
+//     describe('When the component is getting loaded, then ngOninit', () => {
 
 //         Initialize104TestBed();
 

--- a/src/app/supervisor-alerts-notifications/supervisor-alerts-notifications.component.spec.ts
+++ b/src/app/supervisor-alerts-notifications/supervisor-alerts-notifications.component.spec.ts
@@ -108,7 +108,7 @@ function Initialize104TestBed() {
 }
 describe('Supervisor-alerts-notifications', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104TestBed();
 

--- a/src/app/supervisor-blood-url/supervisor-blood-url.component.spec.ts
+++ b/src/app/supervisor-blood-url/supervisor-blood-url.component.spec.ts
@@ -84,7 +84,7 @@ function Initialize104TestBed() {
 }
 describe('Supervisor-blood-url', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104TestBed();
 

--- a/src/app/supervisor-calltype-reports/supervisor-calltype-reports.component.spec.ts
+++ b/src/app/supervisor-calltype-reports/supervisor-calltype-reports.component.spec.ts
@@ -93,7 +93,7 @@
 
 // }
 // describe('SupervisorCalltypeReportsComponent', () => {
-//   fdescribe('When the component get initiated', () => {
+//   describe('When the component get initiated', () => {
 //     Initializetestbed();
 //     it('should be created', () => {
 //       expect(component).toBeTruthy();

--- a/src/app/supervisor-configurations/supervisor-configurations.component.spec.ts
+++ b/src/app/supervisor-configurations/supervisor-configurations.component.spec.ts
@@ -54,7 +54,7 @@ function Initialize104TestBed() {
 }
 describe('Supervisor-configurations-component', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104TestBed();
 

--- a/src/app/supervisor-emergency-contacts/supervisor-emergency-contacts.component.spec.ts
+++ b/src/app/supervisor-emergency-contacts/supervisor-emergency-contacts.component.spec.ts
@@ -104,7 +104,7 @@ function Initialize104TestBed() {
 }
 describe('Supervisor-emergency-contacts', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104TestBed();
 

--- a/src/app/supervisor-grievance/grievance.component.spec.ts
+++ b/src/app/supervisor-grievance/grievance.component.spec.ts
@@ -116,7 +116,7 @@
 // }
 // describe('grievance', () => {
 
-//     fdescribe('When the component is getting loaded, then ngOninit', () => {
+//     describe('When the component is getting loaded, then ngOninit', () => {
 
 //         Initialize104TestBed();
 

--- a/src/app/supervisor-location-communication/supervisor-location-communication.component.spec.ts
+++ b/src/app/supervisor-location-communication/supervisor-location-communication.component.spec.ts
@@ -101,7 +101,7 @@ function Initialize104TestBed() {
 }
 describe('Supervisor-location-communication', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104TestBed();
 

--- a/src/app/supervisor-notifications/supervisor-notifications.component.spec.ts
+++ b/src/app/supervisor-notifications/supervisor-notifications.component.spec.ts
@@ -132,7 +132,7 @@ function Initialize104coTestBed() {
     });
 }
 describe('SupervisorNotificationsComponent Testbed creation', () => {
-    fdescribe('When the component is getting loaded, then ngOninit', () => {
+    describe('When the component is getting loaded, then ngOninit', () => {
         Initialize104coTestBed()
 
         it('should be created', () => {

--- a/src/app/supervisor-reports/supervisor-reports.component.spec.ts
+++ b/src/app/supervisor-reports/supervisor-reports.component.spec.ts
@@ -80,7 +80,7 @@ function Initialize104coTestBed() {
 
 describe('Supervisor-reports', () => {
 
-    fdescribe('When the component is getting loaded, then ngOninit', () => {
+    describe('When the component is getting loaded, then ngOninit', () => {
 
         Initialize104coTestBed();
 

--- a/src/app/supervisor-training-resources/supervisor-training-resources.component.spec.ts
+++ b/src/app/supervisor-training-resources/supervisor-training-resources.component.spec.ts
@@ -107,7 +107,7 @@ function Initialize104coTestBed() {
 
 describe('Supervisor-Training-resources', () => {
 
-    fdescribe('When the component is getting loaded, then ngOninit', () => {
+    describe('When the component is getting loaded, then ngOninit', () => {
 
         Initialize104coTestBed();
 

--- a/src/app/supervisor-upload-schemes/supervisor-upload-schemes.spec.ts
+++ b/src/app/supervisor-upload-schemes/supervisor-upload-schemes.spec.ts
@@ -108,7 +108,7 @@ function Initialize104TestBed() {
 }
 describe('Supervisor-upload-schemes', () => {
 
-    fdescribe('When the component is getting loaded, then ngOninit', () => {
+    describe('When the component is getting loaded, then ngOninit', () => {
 
         Initialize104TestBed();
 

--- a/src/app/surveyor-calltype-reports/surveyor-calltype-reports.component.spec.ts
+++ b/src/app/surveyor-calltype-reports/surveyor-calltype-reports.component.spec.ts
@@ -119,7 +119,7 @@
 // }
 // describe('Surveyor-calltype-reports-components', () => {
 
-//     fdescribe('When the component is getting loaded, then ngOninit', () => {
+//     describe('When the component is getting loaded, then ngOninit', () => {
 
 //         Initialize104TestBed();
 

--- a/src/app/training-resources/training-resources.component.spec.ts
+++ b/src/app/training-resources/training-resources.component.spec.ts
@@ -109,7 +109,7 @@ function Initialize104coTestBed() {
 
 describe('Training-resources', () => {
 
-  fdescribe('When the component is getting loaded, then ngOninit', () => {
+  describe('When the component is getting loaded, then ngOninit', () => {
 
     Initialize104coTestBed();
 


### PR DESCRIPTION
## 📋 Description

JIRA ID: #129

This PR resolves a testing anti-pattern where `fdescribe` (focused describe) was used in multiple test specifications. `fdescribe` causes the test runner to skip all other tests in the application, which can hide failures and artificially inflate pass rates.

**Summary of changes:**
- Replaced all instances of `fdescribe` with standard `describe` across 30 `.spec.ts` files.
- Verified via global search that no `fdescribe` instances remain in the codebase.

This change ensures that the entire test suite executes when running tests, providing accurate feedback on the project's health.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

- Verified that all replacements were successful and no active or commented-out `fdescribe` instances remain.
- Due to the missing `@angular/core` in `node_modules` locally, the tests could not be run to verify the count, but the code changes are strictly limited to replacing `fdescribe` with `describe`.
